### PR TITLE
Add baseline docs, SDK discovery notes, and staged execution plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,78 @@
 # Even Hub Starter Kit (Probe + Template)
 
-This is a **no-build**, GitHub-Pages-friendly starter kit for Even Hub plugins.
+Zero-build, GitHub-Pages-friendly starter kit for validating Even Hub SDK behavior on real hardware.
 
-It gives you:
-- A button-driven **probe harness** to test each SDK method on real hardware
-- An auto-updating **capabilities matrix** (what works, what returns, what fails)
-- A clean base you can clone for future plugins
+## What this project is
+This repo is a **developer probe harness**, not a polished user product yet.
 
-## Files
-- `index.html` – UI + buttons + log output
-- `app.js` – SDK loader + probes + matrix capture
+It provides:
+- Button-driven probes for common Even Hub SDK methods.
+- Runtime status pills (SDK load, bridge readiness, startup page state).
+- In-memory capabilities matrix that captures what worked vs failed.
 
-## How to run (GitHub Pages)
-1. Put these files in a folder in your repo (or root).
-2. In GitHub: **Settings → Pages**
-3. Source: **Deploy from a branch**
-4. Branch: `main` (or whatever) and folder: `/ (root)` or `/docs` depending on where you placed files
-5. Save.
+## Ground truth dependency
+### SDK
+- **Package:** `@evenrealities/even_hub_sdk`
+- **Version used:** `0.0.7`
+- **Current load path:** dynamic import from CDN in `app.js`.
 
-After a minute, GitHub will show a Pages URL like:
+Load order in code:
+1. `https://esm.sh/@evenrealities/even_hub_sdk@0.0.7`
+2. `https://unpkg.com/@evenrealities/even_hub_sdk@0.0.7/dist/index.js`
 
-`https://<username>.github.io/<repo>/path/to/index.html`
+### Minimal usage snippet (from this repo)
+```js
+const { waitForEvenAppBridge, EvenAppBridge } = await import(
+  "https://esm.sh/@evenrealities/even_hub_sdk@0.0.7"
+);
+EvenAppBridge.getInstance();
+const bridge = await waitForEvenAppBridge();
+const user = await bridge.getUserInfo();
+```
 
-Use that URL as your Even Hub QR target.
+## Repo tour
+- `index.html` — UI: status pills, probe buttons, log panel, matrix panel.
+- `app.js` — bridge boot flow, SDK loading, probe implementations, matrix updates.
+- `CAPABILITIES.md` — template for recording method-level results.
+- `docs/BASELINE.md` — current run-state and known failures.
+- `docs/SDK_NOTES.md` — discovered API surfaces and hello-world path.
 
-## Why Pages URL matters
-Raw GitHub URLs often:
-- return `text/plain`
-- don’t send the right headers for module loading
-- get blocked or displayed as source
+## How to run
+### Option A: local smoke check (desktop)
+```bash
+python3 -m http.server 4173
+```
+Open `http://localhost:4173/index.html`.
 
-Pages serves proper HTML + JS over HTTPS with sane headers.
+What you should see:
+- UI loads.
+- Boot may fail due to missing Even runtime bridge (expected outside device runtime).
 
-## Notes
-- The SDK import tries:
-  1) esm.sh
-  2) unpkg (dist/index.js)
-  If one fails, the other usually works.
+### Option B: target Even runtime (recommended)
+1. Host this folder over HTTPS (GitHub Pages recommended).
+2. Use the hosted URL in Even Hub QR target flow.
+3. Click **Boot / Reconnect**.
+4. Click **createStartUpPageContainer()** for hello-world validation.
 
-- The matrix is in-memory. If you want persistence, we can add:
-  - “Download matrix.json”
-  - “Save matrix to Even local storage”
-  - “POST matrix to your server”
+## Smallest reproducible hello-world (core integration)
+1. Launch in Even runtime.
+2. Click **Boot / Reconnect** until `Bridge ready: ready ✅`.
+3. Click **createStartUpPageContainer()**.
+4. Confirm startup status updates and inspect log + matrix output.
+
+## Current constraints
+- Device/runtime dependency: full validation requires Even bridge (`flutter_inappwebview`).
+- SDK/platform are pilot-stage; behavior can change.
+- Discord + official Even Hub channels are upstream truth for latest guidance.
+
+Official sources:
+- Pilot article: https://support.evenrealities.com/hc/en-us/articles/34380533765145-Even-Hub-Pilot-Program
+- Developer portal: https://evenhub.evenrealities.com/
+
+## Documentation index
+- `docs/BASELINE.md`
+- `docs/PRODUCT.md`
+- `docs/FEATURE_PLAN.md`
+- `docs/SDK_NOTES.md`
+- `docs/TROUBLESHOOTING.md`
+- `docs/TODO_UNKNOWNs.md`

--- a/docs/BASELINE.md
+++ b/docs/BASELINE.md
@@ -1,0 +1,46 @@
+# Baseline Report (Phase 0)
+
+## Repo inventory
+- **Project type:** Static web app (no bundler, no package manager files).
+- **Primary entry point:** `index.html` loads `app.js` as an ES module.
+- **SDK usage:** Runtime CDN import of `@evenrealities/even_hub_sdk@0.0.7` from `esm.sh` with `unpkg` fallback.
+- **Runtime assumption:** Designed to run inside the Even companion app WebView with `window.flutter_inappwebview.callHandler` available.
+
+## How to run
+### Fast local smoke check (desktop browser)
+```bash
+python3 -m http.server 4173
+```
+Then open: `http://localhost:4173/index.html`
+
+Expected behavior on desktop: UI renders, but bridge methods fail because `flutter_inappwebview` bridge is absent.
+
+### Target runtime (Even Hub / device flow)
+1. Host the project over HTTPS (GitHub Pages recommended).
+2. Open the hosted URL in Even Hub QR target flow.
+3. Click **Boot / Reconnect** and probe buttons.
+
+## What currently works
+- The page renders without a build step.
+- Probe UI buttons wire correctly to JS handlers.
+- SDK loading logic attempts two CDNs and logs results.
+- In-memory capabilities matrix updates from probe outcomes.
+
+## What currently fails / known limits
+- On standard desktop browser, Even bridge is unavailable; boot may fail with:
+  - `Bridge not available (boot failed).`
+  - `Boot FAILED: ...` (root cause is missing `window.flutter_inappwebview.callHandler`).
+- True end-to-end validation requires Even runtime/device; repository has no simulator harness.
+- No automated tests/lint/build scripts exist yet.
+
+## Missing prerequisites
+- Access to Even Hub pilot program + Discord for latest platform guidance.
+- Physical device/runtime context (or official simulator if provided by Even).
+- HTTPS hosting URL for QR workflow (GitHub Pages or equivalent).
+
+## Top 5 immediate fixes
+1. Add docs clarifying desktop vs device expectations and exact hello-world workflow.
+2. Add explicit dependency/version documentation for `@evenrealities/even_hub_sdk`.
+3. Add unknowns/risk tracker tied to Discord/SDK drift.
+4. Add troubleshooting doc with common boot/bridge failures.
+5. Optional: pin SDK import URL in one place/config to simplify upgrades.

--- a/docs/FEATURE_PLAN.md
+++ b/docs/FEATURE_PLAN.md
@@ -1,0 +1,32 @@
+# Feature Plan (Phase 2 prep)
+
+## MVP features (current + next)
+1. **Reliable bridge bootstrap**
+   - status indicators and boot retry.
+2. **Core probe coverage**
+   - user/device info, startup container lifecycle, local storage, mic control, shutdown.
+3. **Actionable diagnostics**
+   - structured logs + capabilities matrix that can be exported.
+
+## Nice-to-have
+- Persist/export capabilities matrix (`download .json`).
+- Configurable container payload editor in UI.
+- Runtime environment panel (SDK URL, user-agent, bridge capabilities snapshot).
+
+## Dependencies
+- Even Hub SDK APIs listed in `docs/SDK_NOTES.md`.
+- Even runtime WebView bridge (`flutter_inappwebview`).
+- HTTPS hosting for QR/device launch.
+
+## Risks / unknowns
+- SDK/API behavior drift during pilot.
+- Return value inconsistencies across firmware/runtime versions.
+- Limited visibility into undocumented error codes.
+
+## Milestones + acceptance criteria
+1. **Milestone A: deterministic boot diagnostics**
+   - Acceptance: boot result always leaves a clear status + log reason.
+2. **Milestone B: hello-world page create path**
+   - Acceptance: `createStartUpPageContainer` reports success/failure deterministically.
+3. **Milestone C: matrix export**
+   - Acceptance: developer can save probe results and share externally.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,0 +1,18 @@
+# Product Definition (repo-derived)
+
+## Vision
+Even Hub Starter Kit is a zero-build probe harness for validating Even Hub SDK behavior on real hardware before building a full product plugin.
+
+## Primary user story
+As an Even Hub developer, I need a single QR-loadable page where I can boot the bridge, run probe actions, and capture what APIs actually work in my runtime so I can de-risk later feature development.
+
+## MVP scope
+- Bridge boot and status visualization.
+- Manual probes for core SDK methods.
+- Structured log output.
+- In-memory capabilities matrix.
+
+## Non-goals (current repo)
+- Polished end-user product UX.
+- Backend services or persistent storage.
+- Automated CI test coverage of device-only APIs.

--- a/docs/SDK_NOTES.md
+++ b/docs/SDK_NOTES.md
@@ -1,0 +1,40 @@
+# SDK Notes (Phase 1 discovery)
+
+## Identified SDK package
+- **Package:** `@evenrealities/even_hub_sdk`
+- **Version in use:** `0.0.7`
+- **Load strategy in repo:** dynamic ESM import from:
+  1. `https://esm.sh/@evenrealities/even_hub_sdk@0.0.7`
+  2. `https://unpkg.com/@evenrealities/even_hub_sdk@0.0.7/dist/index.js`
+
+## API surfaces used by this repo
+- Bridge bootstrap:
+  - `waitForEvenAppBridge()`
+  - `EvenAppBridge.getInstance()`
+- Events:
+  - `onDeviceStatusChanged(cb)`
+  - `onEvenHubEvent(cb)`
+- Read APIs:
+  - `getUserInfo()`
+  - `getDeviceInfo()`
+  - `getLocalStorage(key)`
+- Write/control APIs:
+  - `setLocalStorage(key, value)`
+  - `createStartUpPageContainer(payload)`
+  - `textContainerUpgrade(payload)`
+  - `rebuildPageContainer(payload)`
+  - `audioControl(boolean)`
+  - `shutDownPageContainer(exitMode)`
+- Payload classes:
+  - `CreateStartUpPageContainer`
+  - `TextContainerUpgrade`
+  - `RebuildPageContainer`
+
+## Minimal hello-world path
+1. Boot bridge.
+2. Call `createStartUpPageContainer()` with one text object.
+3. Verify return code and status pill updates.
+
+## Constraints / caveats
+- Desktop browser is not enough for full verification; Even runtime bridge is required.
+- SDK and behavior may change during pilot; treat Discord announcements as current source of truth.

--- a/docs/TODO_UNKNOWNs.md
+++ b/docs/TODO_UNKNOWNs.md
@@ -1,0 +1,9 @@
+# TODO Unknowns
+
+1. Confirm whether `@evenrealities/even_hub_sdk@0.0.7` is the latest supported version in pilot.
+2. Confirm official simulator availability and setup steps (if any).
+3. Confirm canonical interpretation of container API return codes across firmware versions.
+4. Determine whether `audioControl` requires explicit permissions/setup steps.
+5. Decide export target for capabilities matrix (file download vs API endpoint).
+
+> Source-of-truth follow-up location: Even Hub Discord announcements/pinned messages.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,26 @@
+# Troubleshooting
+
+## `flutter_inappwebview` shows missing ❌
+Cause: page opened in normal desktop/mobile browser, not Even runtime WebView.
+
+Fix: launch through Even Hub flow on device and re-run Boot.
+
+## SDK import fails from CDN
+Possible causes:
+- network restrictions
+- CDN outage
+- version removal
+
+Fixes:
+1. verify internet access in runtime
+2. test both CDN URLs from `app.js`
+3. pin/update SDK version once verified in Discord
+
+## Boot fails / bridge not available
+Common error:
+- `Bridge not available (boot failed).`
+
+Fixes:
+1. ensure Even runtime context is active
+2. press **Boot / Reconnect** again
+3. inspect Log panel for preceding root-cause message


### PR DESCRIPTION
### Motivation
- Provide the Phase 0/1 artifacts required to move the Even Hub starter from exploratory code to a repeatable developer workflow (baseline, SDK identification, and a short execution plan). 
- Make the repo self-explanatory about runtime constraints (device WebView bridge, HTTPS hosting, and Discord as upstream truth) so subsequent work targets the right environment. 
- Capture open questions, risks, and a minimal hello-world path to reduce back-and-forth when implementing Phase 1 features. 

### Description
- Rewrote `README.md` to include a repo tour, dependency declaration for `@evenrealities/even_hub_sdk@0.0.7`, a minimal usage snippet, and local vs device run instructions. 
- Added documentation files `docs/BASELINE.md`, `docs/SDK_NOTES.md`, `docs/PRODUCT.md`, `docs/FEATURE_PLAN.md`, `docs/TODO_UNKNOWNs.md`, and `docs/TROUBLESHOOTING.md` covering inventory, API surfaces, hello-world path, feature plan, unknowns, and troubleshooting. 
- Changes are documentation and runbook focused (no functional edits to `app.js` or `index.html`), to prepare the repository for small, reviewable Phase 1 implementation tasks. 

### Testing
- Validated JavaScript syntax with `node --check app.js`, which completed without errors. 
- Performed a local smoke test by serving the repo with `python3 -m http.server 4173 --bind 127.0.0.1` and requesting `http://127.0.0.1:4173/index.html`, which returned `HTTP/1.0 200 OK`. 
- Confirmed and documented the expected desktop failure mode where the Even runtime bridge (`window.flutter_inappwebview`) is absent so boot/probe actions will fail outside the device WebView.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eac64ec1c8333b562e4ec6685698b)